### PR TITLE
Ensure deterministic DyNeRF training for cut_roasted_beef

### DIFF
--- a/arguments/__init__.py
+++ b/arguments/__init__.py
@@ -147,6 +147,7 @@ class OptimizationParams(ParamGroup):
         self.opacity_threshold_fine_after = 0.005
         self.batch_size=1
         self.add_point=False
+        self.seed = 0
         super().__init__(parser, "Optimization Parameters")
 
 def get_combined_args(parser : ArgumentParser):

--- a/train.py
+++ b/train.py
@@ -12,7 +12,6 @@ import numpy as np
 import random
 import os, sys
 import torch
-from random import randint
 from utils.loss_utils import l1_loss, ssim, l2_loss, lpips_loss
 from gaussian_renderer import render, network_gui
 import sys
@@ -39,7 +38,7 @@ try:
     TENSORBOARD_FOUND = True
 except ImportError:
     TENSORBOARD_FOUND = False
-def scene_reconstruction(dataset, opt, hyper, pipe, testing_iterations, saving_iterations, 
+def scene_reconstruction(dataset, opt, hyper, pipe, testing_iterations, saving_iterations,
                          checkpoint_iterations, checkpoint, debug_from,
                          gaussians, scene, stage, tb_writer, train_iter,timer):
     first_iter = 0
@@ -76,6 +75,11 @@ def scene_reconstruction(dataset, opt, hyper, pipe, testing_iterations, saving_i
     train_cams = scene.getTrainCameras()
 
 
+    if not hasattr(opt, "_torch_generator"):
+        opt._torch_generator = torch.Generator(device='cpu')
+        opt._torch_generator.manual_seed(opt.seed)
+    data_generator = opt._torch_generator
+
     if not viewpoint_stack and not opt.dataloader:
         # dnerf's branch
         viewpoint_stack = [i for i in train_cams]
@@ -87,10 +91,10 @@ def scene_reconstruction(dataset, opt, hyper, pipe, testing_iterations, saving_i
         viewpoint_stack = scene.getTrainCameras()
         if opt.custom_sampler is not None:
             sampler = FineSampler(viewpoint_stack)
-            viewpoint_stack_loader = DataLoader(viewpoint_stack, batch_size=batch_size,sampler=sampler,num_workers=16,collate_fn=list)
+            viewpoint_stack_loader = DataLoader(viewpoint_stack, batch_size=batch_size,sampler=sampler,num_workers=0,collate_fn=list)
             random_loader = False
         else:
-            viewpoint_stack_loader = DataLoader(viewpoint_stack, batch_size=batch_size,shuffle=True,num_workers=16,collate_fn=list)
+            viewpoint_stack_loader = DataLoader(viewpoint_stack, batch_size=batch_size,shuffle=True,num_workers=0,collate_fn=list,generator=data_generator)
             random_loader = True
         loader = iter(viewpoint_stack_loader)
     
@@ -151,7 +155,7 @@ def scene_reconstruction(dataset, opt, hyper, pipe, testing_iterations, saving_i
             except StopIteration:
                 print("reset dataloader into random dataloader.")
                 if not random_loader:
-                    viewpoint_stack_loader = DataLoader(viewpoint_stack, batch_size=opt.batch_size,shuffle=True,num_workers=32,collate_fn=list)
+                    viewpoint_stack_loader = DataLoader(viewpoint_stack, batch_size=opt.batch_size,shuffle=True,num_workers=0,collate_fn=list,generator=data_generator)
                     random_loader = True
                 loader = iter(viewpoint_stack_loader)
 
@@ -159,9 +163,9 @@ def scene_reconstruction(dataset, opt, hyper, pipe, testing_iterations, saving_i
             idx = 0
             viewpoint_cams = []
 
-            while idx < batch_size :    
-                    
-                viewpoint_cam = viewpoint_stack.pop(randint(0,len(viewpoint_stack)-1))
+            while idx < batch_size :
+
+                viewpoint_cam = viewpoint_stack.pop(random.randint(0,len(viewpoint_stack)-1))
                 if not viewpoint_stack :
                     viewpoint_stack =  temp_list.copy()
                 viewpoint_cams.append(viewpoint_cam)
@@ -385,17 +389,17 @@ def training_report(tb_writer, iteration, Ll1, loss, l1_loss, elapsed, testing_i
         
         torch.cuda.empty_cache()
 def setup_seed(seed):
-     torch.manual_seed(seed)
-     torch.cuda.manual_seed_all(seed)
-     np.random.seed(seed)
-     random.seed(seed)
-     torch.backends.cudnn.deterministic = True
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+    np.random.seed(seed)
+    random.seed(seed)
+    torch.backends.cudnn.deterministic = True
+    torch.backends.cudnn.benchmark = False
 if __name__ == "__main__":
     # Set up command line argument parser
     # torch.set_default_tensor_type('torch.FloatTensor')
     torch.cuda.empty_cache()
     parser = ArgumentParser(description="Training script parameters")
-    setup_seed(6666)
     lp = ModelParams(parser)
     op = OptimizationParams(parser)
     pp = PipelineParams(parser)
@@ -411,7 +415,7 @@ if __name__ == "__main__":
     parser.add_argument("--start_checkpoint", type=str, default = None)
     parser.add_argument("--expname", type=str, default = "")
     parser.add_argument("--configs", type=str, default = "")
-    
+
     args = parser.parse_args(sys.argv[1:])
     args.save_iterations.append(args.iterations)
     if args.configs:
@@ -422,7 +426,8 @@ if __name__ == "__main__":
     print("Optimizing " + args.model_path)
 
     # Initialize system state (RNG)
-    safe_state(args.quiet)
+    setup_seed(args.seed)
+    safe_state(args.quiet, args.seed)
 
     # Start GUI server, configure and run training
     network_gui.init(args.ip, args.port)

--- a/utils/general_utils.py
+++ b/utils/general_utils.py
@@ -115,7 +115,7 @@ def build_scaling_rotation(s, r):
     L = R @ L
     return L
 
-def safe_state(silent):
+def safe_state(silent, seed=None):
     old_f = sys.stdout
     class F:
         def __init__(self, silent):
@@ -132,8 +132,9 @@ def safe_state(silent):
             old_f.flush()
 
     sys.stdout = F(silent)
-
-    random.seed(0)
-    np.random.seed(0)
-    torch.manual_seed(0)
+    if seed is not None:
+        random.seed(seed)
+        np.random.seed(seed)
+        torch.manual_seed(seed)
+        torch.cuda.manual_seed_all(seed)
     torch.cuda.set_device(torch.device("cuda:0"))


### PR DESCRIPTION
## Summary
- add a seed option to the optimization parameters and thread it through the training entrypoint
- initialize RNG state exactly once per run, disable cuDNN benchmarking, and allow `safe_state` to reuse the configured seed
- reuse a shared torch generator for DyNeRF camera sampling so DataLoader shuffles stay deterministic

## Testing
- python -m compileall train.py utils/general_utils.py arguments/__init__.py

------
https://chatgpt.com/codex/tasks/task_e_68d941b266ac8320a82b94bfcc0b8114